### PR TITLE
Update build-and-deploy.yml

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,14 +34,6 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: ./dist
-          
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
Collapsing to a single build and deploy step. The build step is looking for the url as an output from steps.deployment... when steps.deployment won't start until build is completed.

Looking at this [starter workflow](https://github.com/actions/starter-workflows/blob/main/pages/static.yml) as an example