### PR TITLE
Add month end event for customer change logic

### DIFF
--- a/src/config/baseSettings.ts
+++ b/src/config/baseSettings.ts
@@ -1,7 +1,0 @@
-export const baseSettings = () => {
-    const settings: GameSettings = {
-        music: true,
-        soundEffects: true
-    }
-    return settings;
-}

--- a/src/config/game.ts
+++ b/src/config/game.ts
@@ -1,0 +1,4 @@
+export const gameConfig = {
+    // number of milliseconds
+    dayLength: 2 * 1000,
+}

--- a/src/config/newGame.ts
+++ b/src/config/newGame.ts
@@ -6,6 +6,7 @@ export const newGameState = () => {
       cash: 2000,
       revenue: 50,
       costs: 30,
+      profit: 20,
       facility: 1,
       developers: 0,
       servers: {

--- a/src/config/newGame.ts
+++ b/src/config/newGame.ts
@@ -11,7 +11,9 @@ export const newGameState = () => {
       servers: {
         1: 1
       },
-      customers: 1,
+      customers: {
+        1: 1
+      },
       products: {
         1: 50
       },

--- a/src/config/newGame.ts
+++ b/src/config/newGame.ts
@@ -35,7 +35,6 @@ export const newGameState = () => {
     clock: {
       year: 0,
       month: 0,
-      week: 0,
       day: 0,
       isPaused: false,
     },

--- a/src/events/eventCenter.ts
+++ b/src/events/eventCenter.ts
@@ -24,7 +24,6 @@ export enum ClockEvents {
   CLOCK_UPDATE_DATE = 'clock.update.date',
   CLOCK_MONTH_END = 'clock.month.end',
   CLOCK_YEAR_END = 'clock.year.end',
-  CLOCK_WEEK_END = 'clock.week.end',
   CLOCK_DAY_END = 'clock.day.end',
   CLOCK_PAUSE = 'clock.pause',
   CLOCK_RESUME = 'clock.resume',

--- a/src/logic/progression.ts
+++ b/src/logic/progression.ts
@@ -18,7 +18,7 @@ export const progressMonth = (game: Game, levelState: Level): Game => {
     for (const [id, customer] of Object.entries(levelState.customers)) {
         const customersGained = Math.floor(getRandomCustomerNumber(customer.joinRate) * customerAcquisitionMultiplier);
         console.log(customersGained);
-        game.addCustomers(customersGained, Number(id));
+        game.addCustomers(customersGained, Number(id), levelState);
     }
 
     // Gain money and save game

--- a/src/logic/progression.ts
+++ b/src/logic/progression.ts
@@ -1,0 +1,31 @@
+import { Game } from "../objects/game";
+
+// Month progression marks a significant change in the game state, as well as a 
+// game save point. This function is called at the end of each month.
+export const progressMonth = (game: Game, levelState: Level): Game => {
+    // Customer attrition and acquisition can be impacted by the cost of products
+    let customerAcquisitionMultiplier = 1;
+    let customerAttritionMultiplier = 1;
+
+    // Lose customers
+    for (const [id, customer] of Object.entries(levelState.customers)) {
+        const customersLost = Math.floor(1 - Math.pow(customer.loyalty, customerAttritionMultiplier));
+        console.log(customersLost);
+        game.deleteCustomers(customersLost, Number(id));
+    }
+
+    // Gain customers
+    for (const [id, customer] of Object.entries(levelState.customers)) {
+        const customersGained = Math.floor(getRandomCustomerNumber(customer.joinRate) * customerAcquisitionMultiplier);
+        console.log(customersGained);
+        game.addCustomers(customersGained, Number(id));
+    }
+
+    // Gain money and save game
+    game.updateCash(levelState);
+    return game;
+}
+
+const getRandomCustomerNumber = (customerJoinRate: number): number => {
+    return Math.floor(Math.random() * customerJoinRate);
+}

--- a/src/logic/progression.ts
+++ b/src/logic/progression.ts
@@ -23,7 +23,18 @@ export const progressMonth = (game: Game, levelState: Level): Game => {
 
     // Gain money and save game
     game.updateCash(levelState);
+
+    // Check level progression
+    const profit = game.getProfit();
+    if (profit >= levelState.goal) {
+        progressLevel();
+    }
     return game;
+}
+
+const progressLevel = () => {
+    // Do something here to progress to the next level
+    console.log("Next Level!!!")
 }
 
 const getRandomCustomerNumber = (customerJoinRate: number): number => {

--- a/src/objects/game.ts
+++ b/src/objects/game.ts
@@ -77,6 +77,10 @@ export class Game  {
     public setCost(cost: number): void {
         this.playerBusiness.costs = cost;
     }
+
+    public getProfit(): number {
+        return this.playerBusiness.profit;
+    }
     
     public getFacility(): number {
         return this.playerBusiness.facility;
@@ -126,8 +130,14 @@ export class Game  {
     public updateCash(currentLevel: Level): void {
         this.calculateRevenue();
         this.calculateCost(currentLevel);
-        this.playerBusiness.cash = (this.playerBusiness.cash + this.playerBusiness.revenue) - this.playerBusiness.costs;
+        const profit = this.calculateProfit();
+        this.playerBusiness.cash = this.playerBusiness.cash + profit;
         this.updateGameState();
+    }
+
+    private calculateProfit(): number {
+        this.playerBusiness.profit = this.playerBusiness.revenue - this.playerBusiness.costs;
+        return this.playerBusiness.profit;
     }
     
     private calculateRevenue(): number {

--- a/src/objects/game.ts
+++ b/src/objects/game.ts
@@ -248,10 +248,6 @@ export class Game  {
         return this.clock.month;
       }
     
-      public getWeek(): number {
-        return this.clock.week;
-      }
-    
       public getDay(): number {
         return this.clock.day;
       }
@@ -262,10 +258,6 @@ export class Game  {
     
       public setMonth(month: number, date?: number): void {
         this.clock.month = month;
-      }
-    
-      public setWeek(week: number): void {
-        this.clock.week = week;
       }
     
       public setDay(day: number): void {
@@ -289,27 +281,21 @@ export class Game  {
       public updateDate(): void {
         if (!this.getIsPaused()) {
           this.clock.day++;
-          if (this.clock.day > 7) {
+          if (this.clock.day > 28) {
             this.clock.day = 1;
-            this.clock.week++;
-            // Jank but honestly good enough for now
-            eventCenter.emit(ClockEvents.CLOCK_WEEK_END);
-            if (this.clock.week > 4) {
-              this.clock.week = 1;
-              this.clock.month++;
-              eventCenter.emit(ClockEvents.CLOCK_MONTH_END);
-              if (this.clock.month > 12) {
+            this.clock.month++;
+            eventCenter.emit(ClockEvents.CLOCK_MONTH_END);
+            if (this.clock.month > 12) {
                 this.clock.month = 1;
                 this.clock.year++;
                 eventCenter.emit(ClockEvents.CLOCK_YEAR_END);
-              }
             }
           }
         }
       }
     
       public getDateString(): string {
-        return `Y${this.clock.year} M${this.clock.month} W${this.clock.week} D${this.clock.day}`;
+        return `Day ${this.clock.day} Month ${this.clock.month} Year ${this.clock.year}`;
       }
 
     public completeLevelIntro(levelNumber: number): void {

--- a/src/objects/game.ts
+++ b/src/objects/game.ts
@@ -106,12 +106,20 @@ export class Game  {
         return customers;
     }
     
-    public addCustomers(amount: number, id: number): void {
+    public addCustomers(amount: number, id: number, levelState: Level): void {
         // Handle case where this customer type isn't added to the state yet
         if (this.playerBusiness.customers[id]) {
-            this.playerBusiness.customers[id] += amount;
+            if (this.playerBusiness.customers[id] + amount > levelState.customers[id].maximum) {
+                this.playerBusiness.customers[id] = levelState.customers[id].maximum
+            } else {
+                this.playerBusiness.customers[id] += amount;
+            }
         } else {
-            this.playerBusiness.customers[id] = amount;
+            if (amount > levelState.customers[id].maximum) {
+                this.playerBusiness.customers[id] = levelState.customers[id].maximum;
+            } else {
+                this.playerBusiness.customers[id] = amount;
+            }
         }
     }
     

--- a/src/scenes/hudScene.ts
+++ b/src/scenes/hudScene.ts
@@ -43,8 +43,6 @@ export class HUDScene extends BaseScene {
       callbackScope: this,
       loop: true,
     });
-
-    // eventCenter.on(ClockEvents.CLOCK_WEEK_END, this.updateCash, this);
   
     eventCenter.on(ClockEvents.CLOCK_PAUSE, () => this.GameState.Game.pauseClock(), this);
     

--- a/src/scenes/hudScene.ts
+++ b/src/scenes/hudScene.ts
@@ -1,7 +1,10 @@
 import { levels } from '../config/levels';
 import eventCenter, { ClockEvents, GameplayBusinessEvents, GameplayEvents, UIEvents } from '../events/eventCenter';
 import { progressMonth } from '../logic/progression';
+import { getGameWidth, getGameHeight, getColorInt} from '../helpers';
 import { BaseScene } from './baseScene';
+import { colorPalette } from '../../assets/colorPalette';
+import { gameConfig } from '../config/game';
 
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
   active: false,
@@ -26,8 +29,10 @@ export class HUDScene extends BaseScene {
   public create(): void {
     this.add.text(50, 100, 'HUD Scene');
 
+    this.add.rectangle(0, getGameHeight(this) - 40, getGameWidth(this), 40, getColorInt(colorPalette.periwinkle)).setOrigin(0, 0);
+
     // Create a text object to display the day
-    this.dateText = this.add.text(50, 120, this.GameState.Game.getDateString());
+    this.dateText = this.add.text(getGameWidth(this) - 216, getGameHeight(this) - 28, this.GameState.Game.getDateString());
 
     // Create a text object to display the money
     this.cashText = this.add.text(50, 140, 'Cash ' + this.GameState.Game.getCash());
@@ -38,7 +43,7 @@ export class HUDScene extends BaseScene {
 
     // Evey 5 seconds update the time
     this.time.addEvent({
-      delay: 5000,
+      delay: gameConfig.dayLength,
       callback: this.updateDate,
       callbackScope: this,
       loop: true,

--- a/src/scenes/hudScene.ts
+++ b/src/scenes/hudScene.ts
@@ -1,4 +1,6 @@
+import { levels } from '../config/levels';
 import eventCenter, { ClockEvents, GameplayBusinessEvents, GameplayEvents, UIEvents } from '../events/eventCenter';
+import { progressMonth } from '../logic/progression';
 import { BaseScene } from './baseScene';
 
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
@@ -42,8 +44,10 @@ export class HUDScene extends BaseScene {
       loop: true,
     });
 
-    eventCenter.on(ClockEvents.CLOCK_WEEK_END, this.updateCash, this);
+    // eventCenter.on(ClockEvents.CLOCK_WEEK_END, this.updateCash, this);
   
+    eventCenter.on(ClockEvents.CLOCK_PAUSE, () => this.GameState.Game.pauseClock(), this);
+    
     eventCenter.on(ClockEvents.CLOCK_RESUME, () => this.GameState.Game.unPauseClock(), this);
     
     eventCenter.on(GameplayEvents.GAMEPLAY_COMPLETE_LEVEL_INTRO, ({ levelNumber }) => { this.GameState.Game.completeLevelIntro(levelNumber); }, this);
@@ -52,40 +56,13 @@ export class HUDScene extends BaseScene {
       this.GameState.updateGameState();
     })
 
-    eventCenter.on(UIEvents.UI_UPDATE_COSTS,
-      (data) => {
-        console.log('UI_UPDATE_COSTS', data);
-        this.updateCosts(data.event);
-      },
-      this,
-    );
-  }
+    eventCenter.on(ClockEvents.CLOCK_MONTH_END, () => {
+      progressMonth(this.GameState.Game, levels[this.GameState.Game.getCurrentLevel()]);
 
-  // Update the cash on the end of the month
-  private updateCash(): void {
-    console.log('updateCash');
-
-    this.GameState.Game.updateCash();
-
-    this.cashText.setText('Cash ' + this.GameState.Game.getCash());
-  }
-
-  // Update the cost of the business on customer or server change
-  private updateCosts(event: GameplayBusinessEvents): void {
-    console.log('updateCosts', event);
-    switch (event) {
-      case GameplayBusinessEvents.BUSINESS_ADD_CUSTOMER:
-        this.GameState.Game.setCustomers(1);
-        this.customerText.setText('Customers ' + this.GameState.Game.getCustomers());
-        break;
-      case GameplayBusinessEvents.BUSINESS_REMOVE_CUSTOMER:
-        this.GameState.Game.deleteCustomers(1);
-        this.customerText.setText('Customers ' + this.GameState.Game.getCustomers());
-        break;
-    }
-
-    this.GameState.Game.updateCosts();
-    this.costText.setText('Cost ' + this.GameState.Game.getCosts());
+      this.cashText.setText('Cash ' + this.GameState.Game.getCash());
+      this.customerText.setText('Customers ' + this.GameState.Game.getCustomers());
+      this.costText.setText('Cost ' + this.GameState.Game.getCosts());
+    })
   }
 
   private updateDate(): void {

--- a/src/types/gameState.ts
+++ b/src/types/gameState.ts
@@ -23,7 +23,9 @@ interface BusinessState {
     revenue: number; // The current revenue a user is gaining, ex. 4500
     facility: number; // The id of  current facility a user is in, ex. 1, this may need to change to an array if we expand to multiple facilities in the future
     developers: number; // The current number of developers a user has hired, ex. 10
-    customers: number; // The current number of customers a user has, ex. 100
+    customers: {
+        [id: number]: number; // The number of customers a user has of each type, ex. { 1: 5, 2: 10 }
+    } 
     servers: ServerState;
     products: ProductState;
     research: ResearchState;
@@ -44,7 +46,6 @@ interface ServerState {
 interface CustomerState {
     [id: number]: {
         count: number; // The number of this type of customer a user has, ex. 26
-        apps: number; // The total number of apps for this type of customer, ex. 75
     }
 }
 

--- a/src/types/gameState.ts
+++ b/src/types/gameState.ts
@@ -21,6 +21,7 @@ interface BusinessState {
     cash: number; // The current money a user has in the game, ex. 2000
     costs: number; // The current costs a user has, ex. 50
     revenue: number; // The current revenue a user is gaining, ex. 4500
+    profit: number; // The monthly profit a user is gaining, ex. 4450
     facility: number; // The id of  current facility a user is in, ex. 1, this may need to change to an array if we expand to multiple facilities in the future
     developers: number; // The current number of developers a user has hired, ex. 10
     customers: {

--- a/src/types/gameState.ts
+++ b/src/types/gameState.ts
@@ -35,7 +35,6 @@ interface BusinessState {
 interface ClockState {
     year: number; // The current year a user is in, ex. 2019
     month: number; // The current month a user is in, ex. 1
-    week: number; // The current week a user is in, ex. 1
     day: number; // The current day a user is in, ex. 1
     isPaused: boolean; // Whether the game is paused, ex. false
 }

--- a/src/ui/dialogModal.ts
+++ b/src/ui/dialogModal.ts
@@ -53,7 +53,7 @@ const addText = (scene: Phaser.Scene, text: string, animate: boolean) => {
 
         screenText = scene.make.text({
             x: padding + 10,
-            y: getGameHeight(scene) - windowHeight - padding + 10,
+            y: getGameHeight(scene) - windowHeight - padding + 10 - 36,
             text: currentText,
             style: {
                 font: 'bold 16px Arial',

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -2,13 +2,14 @@ import { getColorInt, getGameHeight, getGameWidth } from "../helpers";
 
 const modalPadding = 32;
 const windowHeight = 150;
+const bottomBar = 40;
 
 export const modal = (scene: Phaser.Scene, backgroundColor: string, accentColor: string, onClose: () => void, fullScreen: boolean, onClick?: () => void) => {
     const width = getGameWidth(scene) - (modalPadding * 2);
     const height = fullScreen ? getGameHeight(scene) - (modalPadding * 2) : windowHeight;
     const modalButtonBorderX = getGameWidth(scene) - modalPadding - 20;
-    const modalButtonBorderY = fullScreen ? modalPadding : getGameHeight(scene) - windowHeight - modalPadding;
-    const modalY = fullScreen ? modalPadding : getGameHeight(scene) - windowHeight - modalPadding;
+    const modalButtonBorderY = fullScreen ? modalPadding : getGameHeight(scene) - windowHeight - modalPadding - bottomBar;
+    const modalY = fullScreen ? modalPadding : getGameHeight(scene) - windowHeight - modalPadding - bottomBar;
 
     const close = () => {
         onClose();


### PR DESCRIPTION
Closes https://github.com/knot-games/cloud-tycoon/issues/40

Adds:

* Customer acquisition and attrition
* Month-end event to calculate costs/revenue/cash